### PR TITLE
Leave version number empty to stick always to the latest engine version.

### DIFF
--- a/tor/driver.go
+++ b/tor/driver.go
@@ -376,7 +376,7 @@ func (d *Driver) Leave(r *network.LeaveRequest) error {
 // NewDriver creates a new Driver pointer.
 func NewDriver() (*Driver, error) {
 	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	dcli, err := client.NewClient("unix:///var/run/docker.sock", "v1.21", nil, defaultHeaders)
+	dcli, err := client.NewClient("unix:///var/run/docker.sock", "", nil, defaultHeaders)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to docker: %s", err)
 	}


### PR DESCRIPTION
That way you won't need to change that number for every release :wink: 
